### PR TITLE
refactor: change LinkedList #to_string to use string concatenation

### DIFF
--- a/lib/linked_list.rb
+++ b/lib/linked_list.rb
@@ -20,16 +20,17 @@ class LinkedList
   end
 
   def to_string
-    sounds = []
+    sounds = ""
     if @head != nil
       current_sound_node = @head
-      until current_sound_node == nil
-        sounds << current_sound_node.data
+      sounds << current_sound_node.data
+      until current_sound_node.next_node == nil
         current_sound_node = current_sound_node.next_node
+        sounds << ' ' << current_sound_node.data
       end
     # else (list is empty and head is nil) output some error message?
     end
-    sounds.join(' ')
+    sounds
   end
 
   def prepend(sound)


### PR DESCRIPTION
- previously used an array to store data while traversing through the list and the join method to return a single string
- refactored code to use only string concatenation  
  - With string concatenation, I also included a string for a single space to keep spaces only in between sounds, but to prevent an extra space before the first or after the last, line 26 was added to first add head data without a space.
