### PR TITLE
refactor: update #initialize with argument

### DIFF
--- a/lib/jungle_beat.rb
+++ b/lib/jungle_beat.rb
@@ -1,11 +1,12 @@
 require './lib/linked_list'
 
 class JungleBeat
-  attr_reader :list
+  attr_reader :list, :count
 
-  def initialize
+  def initialize(init_sounds = '')
     @list = LinkedList.new
     @count = @list.count
+    append(init_sounds)
   end
 
   def append(sounds)

--- a/spec/jungle_beat_spec.rb
+++ b/spec/jungle_beat_spec.rb
@@ -20,6 +20,18 @@ RSpec.describe JungleBeat do
 
       expect(jb.count).to eq(6)
     end
+
+    it 'appends every sound it is initialized with' do
+      jb = JungleBeat.new("deep")
+
+      expect(jb.all).to eq("deep")
+    end
+
+    it 'has a default of no sounds' do
+      jb = JungleBeat.new
+
+      expect(jb.all).to eq("")
+    end
   end
 
   describe '#append' do


### PR DESCRIPTION
- allows JungleBeat object to be initialized with sound argument
  - default allows JungleBeat to be initialized with no sound argument
- test specs included for both cases listed above