### PR TITLE
test: add and amend tests

### DIFF
--- a/lib/linked_list.rb
+++ b/lib/linked_list.rb
@@ -23,25 +23,29 @@ class LinkedList
 
   def to_string
     sounds = ""
-    if @head != nil
+    if count == 0
+      "The list is empty."
+    else
       current_sound_node = @head
       sounds << current_sound_node.data
       until current_sound_node.next_node == nil
         current_sound_node = current_sound_node.next_node
         sounds << ' ' << current_sound_node.data
       end
-    else
-      "The list is empty."
+      sounds
     end
-    sounds
   end
 
   def prepend(sound)
-    prepend_node = Node.new(sound)
-    prepend_node.next_node = @head
-    @head = prepend_node
-    @count += 1
-    sound
+    if count == 0
+      append(sound)
+    else
+      prepend_node = Node.new(sound)
+      prepend_node.next_node = @head
+      @head = prepend_node
+      @count += 1
+      sound
+    end
   end
 
   def insert(insert_index, sound)
@@ -85,13 +89,17 @@ class LinkedList
   end
 
   def includes?(sound)
-    current_node = @head
-    included = false
-    until current_node == nil
-      break included = true if current_node.data == sound
-      current_node = current_node.next_node
+    if count == 0
+      "The list is empty."
+    else
+      current_node = @head
+      included = false
+      until current_node == nil
+        break included = true if current_node.data == sound
+        current_node = current_node.next_node
+      end
+      included
     end
-    included
   end
 
   def pop

--- a/spec/jungle_beat_spec.rb
+++ b/spec/jungle_beat_spec.rb
@@ -3,44 +3,26 @@ require './lib/jungle_beat'
 
 RSpec.describe JungleBeat do
   describe '#initialize' do
-    it 'exists' do
+    it 'exists with default values' do
       jb = JungleBeat.new
 
       expect(jb).to be_an_instance_of(JungleBeat)
       expect(jb.list).to be_an_instance_of(LinkedList)
-      expect(jb.list.head).to be_nil
+      expect(jb.rate).to eq(500)
+      expect(jb.voice).to eq("Boing")
+      expect(jb.all).to eq("The list is empty.")
     end
 
-    it 'returns the numbers of sounds in a list' do
+    it 'exists with init_sounds argument' do
       jb = JungleBeat.new
       jb.append("deep doo ditt")
       jb.append("woo hoo shu")
 
+      expect(jb).to be_an_instance_of(JungleBeat)
       expect(jb.count).to eq(6)
-    end
-
-    it 'has a default rate of 500' do
-      jb = JungleBeat.new("deep")
-
       expect(jb.rate).to eq(500)
-    end
-
-    it 'has a default voice of Boing' do
-      jb = JungleBeat.new("deep")
-
       expect(jb.voice).to eq("Boing")
-    end
-
-    it 'appends every sound it is initialized with' do
-      jb = JungleBeat.new("deep")
-
-      expect(jb.all).to eq("deep")
-    end
-
-    it 'has a default of no sounds' do
-      jb = JungleBeat.new
-
-      expect(jb.all).to eq("")
+      expect(jb.all).to eq("deep doo ditt woo hoo shu")
     end
   end
 
@@ -50,6 +32,12 @@ RSpec.describe JungleBeat do
       jb.append("deep")
 
       expect(jb.all).to eq("deep deep")
+    end
+
+    it 'alerts if the list is empty' do
+      jb = JungleBeat.new
+
+      expect(jb.all).to eq("The list is empty.")
     end
   end
 
@@ -65,9 +53,14 @@ RSpec.describe JungleBeat do
 
     it 'omits any word not in defined list' do
       jb = JungleBeat.new
-      jb.append("Mississippi")
 
-      expect(jb.count).to eq(0)
+      expect(jb.append("Mississippi")).to eq(0)
+    end
+
+    it "returns the count of permissible words" do
+      jb = JungleBeat.new
+      
+      expect(jb.append("doo dah Mississippi")).to eq(2)
     end
   end
 
@@ -77,6 +70,16 @@ RSpec.describe JungleBeat do
       jb.append("deep doo ditt")
       jb.append("woo hoo shu")
 
+      expect(jb.play)
+    end
+
+    it 'accepts changed rate and voice' do
+      jb = JungleBeat.new("deep doo ditt woo hoo shu")
+      jb.rate = 100
+      jb.voice = "Daniel"
+      
+      expect(jb.rate).to eq(100)
+      expect(jb.voice).to eq("Daniel")
       expect(jb.play)
     end
   end
@@ -94,6 +97,12 @@ RSpec.describe JungleBeat do
       jb = JungleBeat.new("deep")
 
       expect(jb.prepend("Mississippi")).to eq(0)
+    end
+
+    it "returns the count of permissible words" do
+      jb = JungleBeat.new
+      
+      expect(jb.prepend("doo dah Mississippi")).to eq(2)
     end
   end
 

--- a/spec/linked_list_spec.rb
+++ b/spec/linked_list_spec.rb
@@ -7,17 +7,14 @@ RSpec.describe LinkedList do
       list = LinkedList.new
 
       expect(list).to be_an_instance_of(LinkedList)
-    end
-
-    it 'has a head node with default nil' do
-      list = LinkedList.new
-
       expect(list.head).to eq(nil)
+      expect(list.count).to eq(0)
+      expect(list.tail).to eq(nil)
     end
   end
 
   describe '#append' do
-    it 'appends the first sound as the head node' do
+    it 'appends the first sound as the head and tail' do
       list = LinkedList.new
       list.append("doop")
 
@@ -70,6 +67,12 @@ RSpec.describe LinkedList do
 
       expect(list.to_string).to eq("doop doop deep dop doop doo dah deep dop")
     end
+
+    it 'alerts if list is empty' do
+      list = LinkedList.new
+
+      expect(list.to_string).to eq("The list is empty.")
+    end
   end
 
   describe '#prepend' do
@@ -81,6 +84,17 @@ RSpec.describe LinkedList do
 
       expect(list.to_string).to eq("dop plop suu")
       expect(list.count).to eq(3)
+    end
+
+    it 'adds a sound as the head and tail if the list is empty' do
+      list = LinkedList.new
+      list.prepend("doop")
+
+      expect(list.head).to be_a(Node)
+      expect(list.head.data).to eq("doop")
+      expect(list.head.next_node).to eq(nil)
+      expect(list.count).to eq(1)
+      expect(list.tail).to eq(list.head)
     end
   end
 
@@ -183,8 +197,7 @@ RSpec.describe LinkedList do
     it 'returns false if list is empty' do
       list = LinkedList.new
 
-      expect(list.includes?("deep")).to eq(false)
-      expect(list.includes?("dep")).to eq(false)
+      expect(list.includes?("deep")).to eq("The list is empty.")
     end
   end
 


### PR DESCRIPTION
- amend tests for LinkedList
  -  #initialize with all default values
- add test for empty list alerts
  - #to_string 
  - #prepend 
  - #includes?
- refactor above LinkedList methods to give empty list alert
- amend tests for JungleBeat
  - refactor #initialize tests
    - with default no sounds argument
    - with sounds argument
  - include test for empty list for #all 
  - add test for #append and #prepend to check for return count of permissible sounds
  - add test for changed rate and voice in #play